### PR TITLE
Disable timeouts in FUSE options

### DIFF
--- a/main.go
+++ b/main.go
@@ -68,8 +68,10 @@ func main() {
 	fs.SetDebug(*debug)
 
 	// Create FS connector
-	opts := nodefs.NewOptions()
-	opts.Debug = *fusedebug
+	opts := &nodefs.Options{
+		Owner: fuse.CurrentOwner(),
+		Debug: *fusedebug,
+	}
 	conn := nodefs.NewFileSystemConnector(fs.Root(), opts)
 
 	// Create the FUSE server


### PR DESCRIPTION
With a nonzero attr_timeout, the results of GetAttr() calls are cached
in the kernel.

This is not compatible with my GetAttr() scheme (abb48d25fc), where
stat() returns a size of zero (avoiding an API call), but read() still
returns data as expected. This is because the result of first
(file == nil) GetAttr() call is cached, the subsequent call
(file != nil) never happens.

This fixes #2.
