### PR TITLE
Add builds directory update minimum delay

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,13 @@ You must also provide the following values, either via command-line options or e
 - `GITLAB_PRIVATE_TOKEN` or `-token` - Your GitLab private (or application) token
 - `GITLAB_URL` or `-url` - The URL to your GitLab instance (e.g. `https://gitlab.example.com/api/v3`)
 
+# Options
+
+The following options can be set via environment variables:
+- `GITLABFS_MIN_BUILDS_DIR_UPDATE_DELAY` - This is the minimum amount of time
+  that `gitlab-fuse` will wait between updates to a project's `builds/`
+  directory. (Default: 1 minute)
+
 
 [FUSE]: https://en.wikipedia.org/wiki/Filesystem_in_Userspace
 [GitLab]: https://docs.gitlab.com/ce/api/


### PR DESCRIPTION
This greatly helps with the performance problems encountered when multiple successive OpenDir() calls are made.
